### PR TITLE
DBus feature + `gh` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,37 @@ In your `flake.nix`:
 
 Run with: `nix run .#my-app-sandboxed`
 
+## Reusable Modules
+
+landrun-nix provides reusable modules for common applications via `landrunModules.*`. These can be imported into your app configurations:
+
+```nix
+{
+  inputs.landrun-nix.url = "github:srid/landrun-nix";
+
+  outputs = { flake-parts, landrun-nix, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ landrun-nix.flakeModule ];
+
+      perSystem = { pkgs, ... }: {
+        landrunApps.my-app = {
+          imports = [
+            landrun-nix.landrunModules.gh  # Import GitHub CLI module
+          ];
+          program = "${pkgs.my-app}/bin/my-app";
+          features.network = true;
+        };
+      };
+    };
+}
+```
+
+### Available Modules
+
+| Module | Description |
+|--------|-------------|
+| `landrunModules.gh` | GitHub CLI (`gh`) configuration with D-Bus keyring support |
+
 ## Examples
 
 ### Claude Code
@@ -60,6 +91,7 @@ High-level feature flags automatically configure common sandboxing patterns:
 | `features.nix` | `true` | Nix store, system paths, PATH env var |
 | `features.network` | `false` | DNS resolution, SSL certificates, unrestricted network |
 | `features.tmp` | `true` | Read-write access to /tmp |
+| `features.dbus` | `false` | D-Bus session bus, keyring access for Secret Service API |
 
 ## CLI Options
 

--- a/examples/claude-sandboxed/flake.nix
+++ b/examples/claude-sandboxed/flake.nix
@@ -18,6 +18,9 @@
         };
 
         landrunApps.default = {
+          imports = [
+            landrun-nix.landrunModules.gh  # So, Claude can run `gh` CLI
+          ];
           program = "${pkgs.claude-code}/bin/claude";
           features = {
             tty = true;

--- a/flake.nix
+++ b/flake.nix
@@ -3,5 +3,9 @@
 
   outputs = { ... }: {
     flakeModule = ./flake-module.nix;
+
+    landrunModules = {
+      gh = import ./modules/landrun/gh.nix;
+    };
   };
 }

--- a/modules/landrun/gh.nix
+++ b/modules/landrun/gh.nix
@@ -1,0 +1,6 @@
+{
+  features.dbus = true;
+  cli.ro = [
+    "$HOME/.config/gh"
+  ];
+}


### PR DESCRIPTION

- Add `features.dbus` so keyring access is possible (e.g.: for `gh auth`)
- Add `landrunModules` for re-usable modules. Provide a `gh` module (which uses `dbus` feature among other things)
