### PR TITLE
Make read-only paths optional in landrun wrapper

### DIFF
--- a/modules/flake-parts/landrun/options.nix
+++ b/modules/flake-parts/landrun/options.nix
@@ -55,13 +55,13 @@ in
           rox = mkOption {
             type = types.listOf types.str;
             default = [ ];
-            description = "Paths with read-only + execute access";
+            description = "Paths with read-only + execute access. Non-existent paths are silently ignored.";
           };
 
           ro = mkOption {
             type = types.listOf types.str;
             default = [ ];
-            description = "Paths with read-only access";
+            description = "Paths with read-only access. Non-existent paths are silently ignored.";
           };
 
           rwx = mkOption {

--- a/modules/landrun/git.nix
+++ b/modules/landrun/git.nix
@@ -2,6 +2,7 @@
   features.tty = true;
   cli.ro = [
     "$HOME/.gitconfig"
+    "$HOME/.config/git/config"
   ];
   cli.rw = [
     # Git needs to write to the repository


### PR DESCRIPTION
> [!NOTE]
> This PR description was initially generated by an LLM.

This PR enhances the landrun wrapper to gracefully handle non-existent read-only paths, preventing failures when optional configuration files are missing.

## User-Facing Changes

- The `--ro` and `--rox` path arguments now silently skip non-existent paths instead of failing
- Users can specify optional configuration files (like `~/.config/git/config`) without errors when they don't exist
- The git module now includes `~/.config/git/config` as an optional read-only path

## Developer Notes

- Refactored the wrapper script to build landrun arguments dynamically at runtime
- Introduced `conditionalPathArg` helper that checks path existence before adding to arguments
- Only `--ro` and `--rox` flags are conditional; `--rw` and `--rwx` remain mandatory (fail if missing)
- Updated option descriptions to clarify that non-existent paths are silently ignored